### PR TITLE
Eliminei a forma plural para «gran» como adxectivo. Mantense a forma plu...

### DIFF
--- a/src/volga/main.dic
+++ b/src/volga/main.dic
@@ -3822,7 +3822,7 @@ grafolóxico/10,15 po:adxectivo
 gralleiro/10,15 po:adxectivo
 gramatical/12 po:adxectivo
 gramofónico/10,15 po:adxectivo
-gran/10 po:adxectivo
+gran po:adxectivo
 grandal/12 po:adxectivo
 grandeiro/10,15 po:adxectivo
 grandilocuente/10 po:adxectivo


### PR DESCRIPTION
...ral do substantivo, por suposto.
