### PR TITLE
+oitocentas

### DIFF
--- a/src/norma/main.aff
+++ b/src/norma/main.aff
@@ -1706,7 +1706,8 @@ SFX 17     0     has     un . is:feminino plural
 SFX 17     ún     unhas     ún . is:feminino plural
 SFX 17     eu     úas     seu . is:feminino plural
 SFX 17     os     as     [^l]os . is:feminino plural
-SFX 17     olos     alas     los . is:feminino
+SFX 17     os     as     llos . is:feminino plural
+SFX 17     olos     alas     olos . is:feminino
 SFX 17     ous     úas     dous . is:feminino
 
 

--- a/src/volga/main.dic
+++ b/src/volga/main.dic
@@ -38486,11 +38486,11 @@ mil po:numeral
 novecentos po:numeral
 noventa po:numeral
 oitenta po:numeral
-oitocentos po:numeral
+oitocentos/17 po:numeral
 once po:numeral
 onceavo/15 po:numeral
 quince po:numeral
-quiñentos po:numeral
+quiñentos/17 po:numeral
 seiscentos/17 po:numeral
 sesenta po:numeral
 setecentos/17 po:numeral


### PR DESCRIPTION
+quiñentas
+senllas

A «oitocentos» e «quiñentos» faltáballes o código de sufixo no dicionario. A regra 17 estaba aplicada a «senllos», pero non estaba preparada (de feito, tiña un erro evidente no final, onde o texto para substituír —olos— tiña máis caracteres que o texto de busca —los—).
