### PR TITLE
Desactivada a compresión dos ficheiros (o corrector pasará a ocupar 3 M

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -214,15 +214,19 @@ def getAliasFilepathFor(filepath):
 
 def applyMakealias(aff, dic):
     """ Executa a orde «makealias», de Hunspell, para reducir o tamaño final dos ficheiros considerablemente.
+    
+            Nota: Desactivado de maneira temporal. Véxase:
+            
+                http://sourceforge.net/tracker/?func=detail&aid=3610768&group_id=143754&atid=756395
     """
-    affAlias = getAliasFilepathFor(aff)
-    dicAlias = getAliasFilepathFor(dic)
-    command = 'makealias {dic} {aff}'.format(aff=aff[6:], dic=dic[6:])
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, cwd=os.path.join(os.getcwd(), 'build'))
-    out, err = p.communicate()
-    for filepath in [aff, dic]:
-        os.remove(filepath)
-        os.rename(getAliasFilepathFor(filepath), filepath)
+    #affAlias = getAliasFilepathFor(aff)
+    #dicAlias = getAliasFilepathFor(dic)
+    #command = 'makealias {dic} {aff}'.format(aff=aff[6:], dic=dic[6:])
+    #p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, cwd=os.path.join(os.getcwd(), 'build'))
+    #out, err = p.communicate()
+    #for filepath in [aff, dic]:
+        #os.remove(filepath)
+        #os.rename(getAliasFilepathFor(filepath), filepath)
 
 
 def getModuleListFromModulesString(modulesString):

--- a/src/norma/main.aff
+++ b/src/norma/main.aff
@@ -172,7 +172,7 @@ SFX 16     ao     ás     ao . is:feminino plural
 # ámbolos - ámbalas, entrámbolos - entrámbalas, tódolos - tódalas
 # dous - dúas
 
-SFX 17 Y 31
+SFX 17 Y 32
 SFX 17     ao     á     mao . is:feminino
 SFX 17     an     a     [sv]an . is:feminino
 SFX 17     ó     oa     [sv]ó . is:feminino

--- a/src/norma/main.rep
+++ b/src/norma/main.rep
@@ -137,7 +137,7 @@ champú xampú     # Erro común.
 champurr chapuz     # champurrar → chapuzar.
 champúrr chapúz     # champurrar → chapuzar.
 cerrollo ferrollo     # Erro común.
-choll                 # chollar → choiar
+choll choi # chollar → choiar
 ci ce      # ciar → cear.
 cí ce      # ciar → cear.
 cí cé      # ciar → cear.


### PR DESCRIPTION
...iB en vez de 2) porque esta corrompe o corrector (introduce erros). Xa se informou aos desenvolvedores, que están a revisar o problema.

Arranxados dous erros (descoidos).
