### PR TITLE
Agora o guión para empaquetar inclúe todos os ficheiros de texto simple ...

### DIFF
--- a/scripts/empaquetar.sh
+++ b/scripts/empaquetar.sh
@@ -14,6 +14,10 @@ packageName="hunspell-gl-$(date -u +"%Y%m%d")"
 mkdir ${packageName}
 mv gl.aff ${packageName}/gl.aff
 mv gl.dic ${packageName}/gl.dic
+for filename in $(find .. -name "*.txt")
+do
+  cp "$filename" "${packageName}/"
+done
 tar -cavf ${packageName}.tar.xz ${packageName} &> /dev/null
 mv ${packageName}.tar.xz ../${packageName}.tar.xz
 popd &> /dev/null


### PR DESCRIPTION
...(.txt) no paquete, como «readme-gl.txt».
