### PR TITLE
O corrector pasa a incluír de maneira predeterminada unicamente o vocabul...

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,8 +4,8 @@ import mmap, os, PyICU, re, subprocess
 
 #---# Valores predeterminados #----------------------------------------------------------------------------------------#
 
-defaultAff  = u'norma,unidades'
-defaultDic  = u'comunidade,iso639,iso4217,unidades,volga'
+defaultAff  = u'norma'
+defaultDic  = u'volga'
 defaultRep  = u'comunidade,galipedia'
 defaultCode = u'gl'
 


### PR DESCRIPTION
...ario do VOLG.

Nota: as versións empaquetadas para SourceForge xa incluían só eses módulos, isto é para que ao executar «scons» sen parámetros se usen tamén só eses módulos.
