### PR TITLE
Engadíronse «preinscribir» e «redirixir» ao módulo de comunidade, e prep...

### DIFF
--- a/scripts/empaquetar.sh
+++ b/scripts/empaquetar.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+code="gl_ES"
 
 pushd $rootFolder &> /dev/null
 
@@ -8,12 +9,27 @@ pushd $rootFolder &> /dev/null
 rm -rf ./build
 
 # Construír e empaquetar o corrector principal (VOLG).
-scons aff=norma dic=volga rep=comunidade,galipedia
+scons aff=norma dic=volga rep=comunidade,galipedia code=${code}
 pushd build &> /dev/null
 packageName="hunspell-gl-$(date -u +"%Y%m%d")"
 mkdir ${packageName}
-mv gl.aff ${packageName}/gl.aff
-mv gl.dic ${packageName}/gl.dic
+mv ${code}.aff ${packageName}/${code}.aff
+mv ${code}.dic ${packageName}/${code}.dic
+for filename in $(find .. -name "*.txt")
+do
+  cp "$filename" "${packageName}/"
+done
+tar -cavf ${packageName}.tar.xz ${packageName} &> /dev/null
+mv ${packageName}.tar.xz ../${packageName}.tar.xz
+popd &> /dev/null
+
+# Construír e empaquetar o corrector da comunidade.
+scons aff=norma,trasno,unidades dic=comunidade,galipedia,iso639,iso4217,trasno,unidades,volga rep=comunidade,galipedia code=${code}
+pushd build &> /dev/null
+packageName="hunspell-gl-comunidade-$(date -u +"%Y%m%d")"
+mkdir ${packageName}
+mv ${code}.aff ${packageName}/${code}.aff
+mv ${code}.dic ${packageName}/${code}.dic
 for filename in $(find .. -name "*.txt")
 do
   cp "$filename" "${packageName}/"

--- a/src/comunidade/vocabulario.dic
+++ b/src/comunidade/vocabulario.dic
@@ -2462,3 +2462,9 @@ VLSI
 WAP
 WASP
 XML
+preinscrición/10 po:substantivo feminino
+preinscribir/600,601,800,801 po:verbo ts:transitiva / pronominal t pr al:preinscríbir
+preinscríbir/666,602,802 st:preinscribir ts:alomorfo preinscribir transitiva / pronominal
+redirección/10 po:substantivo feminino
+redirixir/600,601,800,801 po:verbo ts:transitiva / pronominal t pr al:rediríxir
+rediríxir/666,602,802 st:redirixir ts:alomorfo redirixir transitiva / pronominal


### PR DESCRIPTION
...arouse o guión de empaquetación para crear un paquete de comunidade, e usar o código gl_ES.
